### PR TITLE
[WIP] [Feature] #51 - Store selected language in Local Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ For the different types of pre-rendering in `Next.js`, take a look at my article
 
 ## `next-export-i18n` overview
 
-`next-export-i18n` will add a query-parameter `lang` to your urls and use this for setting the correct content for the selected language. The interface for the i18n-content is similar to `react-i18next / next-i18next`. You add get the content with `t(key.to.translation)` from the `useTranslation`-hook.
+`next-export-i18n` will either add a query parameter (default) `lang` to your urls or store it in the browser's local storage. This will be used for setting the correct content for the selected language. The interface for the i18n-content is similar to `react-i18next / next-i18next`. You add get the content with `t(key.to.translation)` from the `useTranslation`-hook.
 There are a few things you need to keep in mind:
 
 - you need to set the translations files as `json`. If you prefer a more human friendly format, use `yaml` and [yamljs](https://www.npmjs.com/package/yamljs) and their cli `yaml2json` for easy conversion.
 - you refer nested keys with a dot: "nested.key" (see example below). Please no not use dots in your keys unless you use nested keys.
 - if there is no translation for the given key, the module renders the key back to the site.
-- you need to update the query parameters on your internal links to pass the selected language query-parameter. Use the `query` state from the `useLanguageQuery`-hook and add it as `query-object` to your `next/link`-components (`<Link href={{ query: query … }}>…`). The `useLanguageQuery`-hook will preserve your existing query-parameters.
+- if you use the query param (default) variant to store your language selection, you need to update the query parameters on your internal links to pass the selected language query-parameter. Use the `query` state from the `useLanguageQuery`-hook and add it as `query-object` to your `next/link`-components (`<Link href={{ query: query … }}>…`). The `useLanguageQuery`-hook will preserve your existing query-parameters.
+- if you use the local storage variant, the above does not apply to you.
 - it requires JavaScript being enabled on the client side.
 
 ## Quick start
@@ -78,6 +79,8 @@ const i18n = {
   },
   defaultLang: "en",
   useBrowserDefault: true,
+  // optional property, will default to "query" if not set
+  languageDataStore: "query" || "localStorage",
 };
 
 module.exports = i18n;

--- a/module/dist/package.json
+++ b/module/dist/package.json
@@ -3,7 +3,7 @@
   "files": ["index.js", "index.d.ts", "README.md", "LICENSE", "package.json"],
 
   "main": "index.js",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Internationalize next.js with true support for next export",
   "keywords": ["next.js", "react.js", "typescript", "i18n", "export", "ssg"],
   "author": "Martin Krause <oss@mkrause.info> (http://mkrause.info/)",

--- a/module/package.dist.json
+++ b/module/package.dist.json
@@ -3,7 +3,7 @@
   "files": ["index.js", "index.d.ts", "README.md", "LICENSE", "package.json"],
 
   "main": "index.js",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Internationalize next.js with true support for next export",
   "keywords": ["next.js", "react.js", "typescript", "i18n", "export", "ssg"],
   "author": "Martin Krause <oss@mkrause.info> (http://mkrause.info/)",

--- a/module/package.json
+++ b/module/package.json
@@ -8,7 +8,7 @@
     "./dist/package.json"
   ],
   "main": "./dist/index.js",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Internationalize next.js with true support for next export",
   "keywords": [
     "next.js",

--- a/module/src/components/language-switcher/index.tsx
+++ b/module/src/components/language-switcher/index.tsx
@@ -1,8 +1,10 @@
-
 import React, { ReactNode } from 'react';
 import { useRouter } from 'next/router';
 import useLanguageQuery from '../../hooks/use-language-query';
 import useLanguageSwitcherIsActive from '../../hooks/use-language-switcher-is-active';
+import i18n from '../../index';
+import { I18N } from '../../types';
+import { LanguageDataStore } from '../../enums/languageDataStore';
 
 type Props = {
 	lang: string,
@@ -31,18 +33,30 @@ const LanguageSwitcher = ({ lang, children, shallow=false }: Props) => {
 	const router = useRouter();
 	const [query] = useLanguageQuery(lang);
 
+  const i18nObj = i18n() as I18N;
+  const languageDataStore = i18nObj.languageDataStore;
+
 	/**
 	 * Updates the router with the currently selected language
 	 */
-	const updateRouter = () => {
-		router.push(
-			{
-				pathname: router.pathname,
-				query: query,
-			},
-			undefined,
-			{ shallow: shallow }
-		);
+	const handleLanguageChange = () => {
+    if (languageDataStore === LanguageDataStore.QUERY) {
+      router.push(
+        {
+          pathname: router.pathname,
+          query: query,
+        },
+        undefined,
+        { shallow: shallow }
+      );
+    }
+
+    if (languageDataStore === LanguageDataStore.LOCAL_STORAGE) {
+      window.localStorage.setItem('lang', lang);
+
+      const event = new Event("localStorageLangChange");
+      document.dispatchEvent(event);
+    }
 	};
 
 	// use React.cloneElement to manipulate properties
@@ -57,7 +71,7 @@ const LanguageSwitcher = ({ lang, children, shallow=false }: Props) => {
 					children.props.onClick();
 				}
 				// set the language
-				updateRouter();
+				handleLanguageChange();
 			},
 			"data-language-switcher": "true",
 			// set the current status
@@ -75,7 +89,7 @@ const LanguageSwitcher = ({ lang, children, shallow=false }: Props) => {
 				data-is-current={languageSwitcherIsActive}
 				onClick={() => {
 					// set the language
-					updateRouter();
+					handleLanguageChange();
 				}}
 			>
 				{children}

--- a/module/src/enums/languageDataStore.ts
+++ b/module/src/enums/languageDataStore.ts
@@ -1,0 +1,4 @@
+export enum LanguageDataStore {
+  QUERY = 'query',
+  LOCAL_STORAGE = 'localStorage',
+}

--- a/module/src/hooks/use-language-switcher-is-active.tsx
+++ b/module/src/hooks/use-language-switcher-is-active.tsx
@@ -1,8 +1,8 @@
-
-import React, { ReactNode, useState, useEffect} from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import i18n from '../index';
 import { I18N } from '../types';
+import { LanguageDataStore } from '../enums/languageDataStore';
 
 /**
  * Returns a boolean react-state indicating if the current selected language equals the one passed to the hook.
@@ -10,23 +10,38 @@ import { I18N } from '../types';
  * @returns boolean react-state
  */
 export default function useLanguageSwitcherIsActive(currentLang: string) {
-	let i18nObj: I18N;
-	i18nObj = i18n() as I18N;
-	const defaultLang: string = i18nObj.defaultLang;
-	const router = useRouter();
-	const [isActive, setIsActive] = useState<boolean>(false);
+  const [isActive, setIsActive] = useState(false);
+  const i18nObj = i18n() as I18N;
+  const { query } = useRouter();
+  const defaultLang = i18nObj.defaultLang;
+  const languageDataStore = i18nObj.languageDataStore;
+
 	useEffect( () => {
-		let current = false;
-		if (!router.query || !router.query.lang) {
-			current = defaultLang === currentLang;
-		}
-		else {
-			current = router.query.lang === currentLang;
-		}
-		setIsActive(current);
-	},[currentLang, defaultLang, router.query]);
-	return { isActive } as const;
-	// return [isActive] as const;
+    if (languageDataStore === LanguageDataStore.QUERY) {
+      let current = query.lang === currentLang;
+
+      if (!query || !query.lang) {
+        current = defaultLang === currentLang;
+      }
+
+      setIsActive(current);
+    }
+	},[currentLang, defaultLang, query, languageDataStore]);
+
+  useEffect( () => {
+    if (languageDataStore === LanguageDataStore.LOCAL_STORAGE) {
+      const localStorageLanguage = window.localStorage.getItem('lang');
+      let current = defaultLang === currentLang;
+
+      if (localStorageLanguage) {
+        current = localStorageLanguage === currentLang;
+      }
+
+      setIsActive(current);
+    }
+  },[currentLang, defaultLang, languageDataStore]);
+
+	return { isActive } as const;
 }
 
 

--- a/module/src/hooks/use-language-switcher-is-active.tsx
+++ b/module/src/hooks/use-language-switcher-is-active.tsx
@@ -12,21 +12,23 @@ import { LanguageDataStore } from '../enums/languageDataStore';
 export default function useLanguageSwitcherIsActive(currentLang: string) {
   const [isActive, setIsActive] = useState(false);
   const i18nObj = i18n() as I18N;
-  const { query } = useRouter();
+  const router = useRouter();
   const defaultLang = i18nObj.defaultLang;
   const languageDataStore = i18nObj.languageDataStore;
 
 	useEffect( () => {
     if (languageDataStore === LanguageDataStore.QUERY) {
-      let current = query.lang === currentLang;
+      let current;
 
-      if (!query || !query.lang) {
+      if (!router.query || !router.query.lang) {
         current = defaultLang === currentLang;
+      } else {
+        current = router.query?.lang === currentLang;
       }
 
       setIsActive(current);
     }
-	},[currentLang, defaultLang, query, languageDataStore]);
+	},[currentLang, defaultLang, router.query, languageDataStore]);
 
   useEffect( () => {
     if (languageDataStore === LanguageDataStore.LOCAL_STORAGE) {

--- a/module/src/hooks/use-selected-language.tsx
+++ b/module/src/hooks/use-selected-language.tsx
@@ -1,30 +1,63 @@
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import i18n from './../index';
 import { I18N } from '../types';
+import { LanguageDataStore } from '../enums/languageDataStore';
 
 /**
  * Returns a react-state containing the currently selected language.
  * @returns [lang as string, setLang as SetStateAction] a react-state containing the currently selected language
  */
 export default function useSelectedLanguage()  {
-	let i18nObj: I18N;
-
-	i18nObj = i18n() as I18N;
+	const i18nObj = i18n() as I18N;
 
 	const defaultLang: string = i18nObj.defaultLang;
 	const translations = i18nObj.translations;
+	const languageDataStore = i18nObj.languageDataStore;
+
 	const router = useRouter();
 	const [lang, setLang] = useState<string>(defaultLang);
 
+  const handleLocalStorageUpdate = useCallback(() => {
+    const localStorageLang = window.localStorage.getItem('lang');
+
+    if (
+      languageDataStore === LanguageDataStore.LOCAL_STORAGE &&
+      localStorageLang &&
+      localStorageLang !== lang &&
+      translations &&
+      translations[localStorageLang]
+    ) {
+      setLang(localStorageLang);
+    }
+
+  }, [translations, lang, setLang, languageDataStore]);
+
 	// set the language if the query parameter changes
 	useEffect(() => {
-		if (router.query.lang && router.query.lang !== lang && translations && translations[router.query.lang as string]) {
-			let lang: string = router.query.lang as string;
-			setLang(lang);
+		if (
+      languageDataStore === LanguageDataStore.QUERY &&
+      router.query.lang &&
+      router.query.lang !== lang &&
+      translations &&
+      translations[router.query.lang as string]
+    ) {
+			setLang(router.query.lang as string);
 		}
 
-	}, [lang, router.query.lang]);
+	}, [lang, router.query.lang, translations, setLang, languageDataStore]);
+
+  useEffect(() => {
+    handleLocalStorageUpdate();
+
+    // Listen for local-storage changes
+    document.addEventListener('localStorageLangChange', handleLocalStorageUpdate);
+
+    return () => {
+      document.removeEventListener('localStorageLangChange', handleLocalStorageUpdate);
+    }
+
+  }, [handleLocalStorageUpdate]);
+
 	return { lang, setLang } as const;
-	// return [lang, setLang] as const;
 }

--- a/module/src/hooks/use-translation.test.tsx
+++ b/module/src/hooks/use-translation.test.tsx
@@ -122,9 +122,5 @@ describe('The hook returns ', () => {
 		useSelectedLanguage.mockImplementation(() => ({
 			lang: 'bar',
 		}));
-
-		// const { result } = renderHook(() => useLanguageQuery('forced'));
-		// expect(result.current).toEqual(expectation);
 	});
 });
-//

--- a/module/src/hooks/use-translation.tsx
+++ b/module/src/hooks/use-translation.tsx
@@ -12,16 +12,14 @@ import Mustache from 'mustache';
  * In case there is no entry for this key, it returns the key.
  * @returns t(key: string): any function
  */
-const useTranslation = ( ) => {
+const useTranslation = () => {
 	const router = useRouter();
 	let i18nObj: I18N;
 
 	i18nObj = i18n() as I18N;
 
 	const translations: Dictionary = i18nObj.translations;
-	const defaultLang: string = i18nObj.defaultLang;  ;
 	const { lang } = useSelectedLanguage();
-	// const [lang] = useSelectedLanguage();
 
 	return {
 		/**

--- a/module/src/index.test.tsx
+++ b/module/src/index.test.tsx
@@ -26,6 +26,7 @@ const mockedData: any = {
   translations: { mock: { title: "mock" }, foo: { title: "bar" } },
   defaultLang: "mock",
   useBrowserDefault: true,
+  languageDataStore: "query",
 };
 
 describe("Without window.navigator", () => {

--- a/module/src/index.tsx
+++ b/module/src/index.tsx
@@ -3,7 +3,8 @@
  */
 
 import { i18n as userland } from "./../../i18n/index";
-import { Dictionary, I18N } from "./types";
+import { I18N } from "./types";
+import { LanguageDataStore } from './enums/languageDataStore';
 
 /**
  * Calculates the default language from the user's language setting and the i18n object.
@@ -47,22 +48,38 @@ const getDefaultLanguage = (userI18n: I18N): string => {
 const i18n = (): I18N | Error => {
   // cast to be typsafe
   const userI18n = userland as I18N;
+
   if (Object.keys(userI18n.translations).length < 1) {
     throw new Error(
       `Missing translations. Did you import and add the tranlations in 'i18n/index.js'?`
     );
   }
+
   if (userI18n.defaultLang.length === 0) {
     throw new Error(
       `Missing default language. Did you set 'defaultLang' in 'i18n/index.js'?`
     );
   }
+
   if (!userI18n.translations[userI18n.defaultLang]) {
     throw new Error(
       `Invalid default language '${userI18n.defaultLang}'. Check your 'defaultLang' in 'i18n/index.js'?`
     );
   }
+
+  // Make query the default storing method, to allow backwards compatibility
+  if (!userI18n.languageDataStore) {
+    userI18n.languageDataStore = LanguageDataStore.QUERY;
+  }
+
+  if (!Object.values(LanguageDataStore).includes(userI18n.languageDataStore)) {
+    throw new Error(
+      `Invalid language detection '${userI18n.languageDataStore}'. Check your 'languageDataStore' in 'i18n/index.js'?`
+    );
+  }
+
   userI18n.defaultLang = getDefaultLanguage(userI18n);
+
   return userI18n;
 };
 

--- a/module/src/types/index.tsx
+++ b/module/src/types/index.tsx
@@ -1,7 +1,10 @@
+import { LanguageDataStore } from '../enums/languageDataStore';
+
 export type Dictionary = { [key: string]: string | Dictionary };
 
 export type I18N = {
   translations: { [language: string]: Dictionary };
   defaultLang: string;
   useBrowserDefault: boolean;
+  languageDataStore?: LanguageDataStore;
 };


### PR DESCRIPTION
This PR allows the user, to store the selected language in the local storage of the browser.

It is possible for the developer, to decide if the language should be stored in the **query** or in the **local storage**.

This is possible due to a new flag in the config file (`./i18n/index`)

**Example:**

```javascript
const en = require('./translations.en.json');
const de = require('./translations.de.json');

const i18n = {
    translations: {
        en,
        de,
    },
    defaultLang: 'en',
    languageDataStore: 'localStorage',
};

module.exports = i18n;
```

The param `languageDataStore` is optional and will default to `'query'`, to ensure backwards compatibility.