### PR TITLE
update useLanguageQuery for dynamic routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# idea
+.idea

--- a/module/dist/index.js
+++ b/module/dist/index.js
@@ -82,7 +82,6 @@ function useSelectedLanguage() {
     // return [lang, setLang] as const;
 }
 
-let passedQuery;
 /**
  * Returns a react-state which is a queryObject containing an exsisting query and a query string with the current selected
  * language (or the passed forced language).
@@ -96,21 +95,19 @@ function useLanguageQuery(forceLang) {
     const router$1 = router.useRouter();
     const [value, setValue] = React.useState();
     // keep passed parameters
-    passedQuery = {};
-    if (router$1.query) {
-        let query = router$1.query;
-        const keys = Object.keys(query);
-        keys.forEach((key, index) => {
-            passedQuery[key] = query[key];
-        });
-    }
+    const passedQuery = React.useMemo(() => {
+        if (!router$1.query) {
+            return {};
+        }
+        return { ...router$1.query };
+    }, [router$1.query]);
     // set lang if one of the dependencies is changing
     React.useEffect(() => {
         setValue({
             ...passedQuery,
             lang: forceLang || lang || passedQuery['lang'],
         });
-    }, [forceLang, lang]);
+    }, [forceLang, lang, passedQuery]);
     return [value];
 }
 

--- a/module/jest.config.js
+++ b/module/jest.config.js
@@ -17,4 +17,5 @@ module.exports = {
     // '@testing-library/react/cleanup-after-each',
     // '@testing-library/jest-dom/extend-expect',
   ],
+  roots: ["./src"]
 };

--- a/module/src/hooks/use-language-query.test.tsx
+++ b/module/src/hooks/use-language-query.test.tsx
@@ -58,9 +58,10 @@ describe('The hook returns ', () => {
 				lang: 'forced',
 			},
 		];
-		useRouter.mockImplementation(() => ({
+		const routerReturn = {
 			query: { bar: 'baz', lang: 'foo' },
-		}));
+		};
+		useRouter.mockImplementation(() => (routerReturn));
 		useSelectedLanguage.mockImplementation(() => ({
 			lang: 'bar',
 		}));
@@ -76,9 +77,10 @@ describe('The hook returns ', () => {
 				lang: 'bar',
 			},
 		];
-		useRouter.mockImplementation(() => ({
+		const routerReturn = {
 			query: { bar: 'baz', lang: 'foo' },
-		}));
+		};
+		useRouter.mockImplementation(() => (routerReturn));
 		useSelectedLanguage.mockImplementation(() => ({
 			lang: 'bar',
 		}));
@@ -94,9 +96,10 @@ describe('The hook returns ', () => {
 				lang: 'foo',
 			},
 		];
-		useRouter.mockImplementation(() => ({
+		const routerReturn = {
 			query: { bar: 'baz', lang: 'foo' },
-		}));
+		};
+		useRouter.mockImplementation(() => (routerReturn));
 		useSelectedLanguage.mockImplementation(() => ({
 			lang: '',
 		}));
@@ -107,15 +110,45 @@ describe('The hook returns ', () => {
 
 	it(`an empty object if there is no query`, async () => {
 		const expectation = [{}];
-		useRouter.mockImplementation(() => ({
+		const routerReturn = {
 			query: null,
-		}));
+		};
+		useRouter.mockImplementation(() => (routerReturn));
 		useSelectedLanguage.mockImplementation(() => ({
 			lang: '',
 		}));
 
 		const { result } = renderHook(() => useLanguageQuery());
 		expect(result.current).toEqual(expectation);
+	});
+
+	it(`updates the query object if route changes`, async () => {
+		const expectation = [{}];
+		const routerReturn = {
+			query: null,
+		};
+		useRouter.mockImplementation(() => (routerReturn));
+		useSelectedLanguage.mockImplementation(() => ({
+			lang: '',
+		}));
+
+		const { result, rerender } = renderHook(() => useLanguageQuery());
+		expect(result.current).toEqual(expectation);
+
+		const newQuery = {
+			id: 'foo',
+			lang: 'en',
+		}
+		useRouter.mockImplementation(() => ({ query: newQuery }))
+
+		// hook rerenders when route changes and query object is updated
+		rerender()
+
+		const expectation2 = [{
+			id: 'foo',
+			lang: 'en'
+		}];
+		expect(result.current).toEqual(expectation2);
 	});
 });
 //

--- a/module/src/hooks/use-language-query.tsx
+++ b/module/src/hooks/use-language-query.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { ParsedUrlQueryInput, ParsedUrlQuery } from 'node:querystring';
-import { useEffect, useState } from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import useSelectedLanguage from './use-selected-language';
 import { Dictionary } from '../types';
 
@@ -21,15 +21,13 @@ export default function useLanguageQuery(forceLang?: string) {
 	const [value, setValue] = useState<ParsedUrlQueryInput>();
 
 	// keep passed parameters
-	passedQuery = {};
+	const passedQuery = useMemo(() => {
+		if (!router.query) {
+			return {};
+		}
 
-	if (router.query) {
-		let query: ParsedUrlQuery = router.query;
-		const keys = Object.keys(query);
-		keys.forEach((key: string, index: number) => {
-			passedQuery[key] = query[key] as string;
-		});
-	}
+		return {...router.query};
+	}, [router.query]);
 
 	// set lang if one of the dependencies is changing
 	useEffect(() => {
@@ -37,7 +35,7 @@ export default function useLanguageQuery(forceLang?: string) {
 			...passedQuery,
 			lang: forceLang || (lang as string) || (passedQuery['lang'] as string),
 		});
-	}, [forceLang, lang]);
+	}, [forceLang, lang, passedQuery]);
 
 	return [value] as const;
 }


### PR DESCRIPTION
This PR fixes handling query params for useLanguageQuery using dynamic routes.

Take this case for example. We have two pages, `index.js` and `[id].js`.

The user first lands on `/` page and wants to go to `/foo`. The `passedQuery` would not be updated because it's not tracked inside dependencies array.

The tests were needed to be updated because query needs to be passed as reference to not be treated as a change.