### PR TITLE
Fix #80 Crashing issue fixed even when Query is used as data store

### DIFF
--- a/module/dist/index.js
+++ b/module/dist/index.js
@@ -285,6 +285,8 @@ const LanguageSwitcher = ({ lang, children, shallow = false, }) => {
             }, undefined, { shallow: shallow });
         }
         if (languageDataStore === LanguageDataStore.LOCAL_STORAGE) {
+            const isLocalStorageAvailable = checkStorageAvailability('localStorage');
+            if(!isLocalStorageAvailable) return
             window.localStorage.setItem("next-export-i18n-lang", lang);
             const event = new Event("localStorageLangChange");
             document.dispatchEvent(event);

--- a/module/dist/index.js
+++ b/module/dist/index.js
@@ -77,6 +77,26 @@ const i18n = () => {
     return userI18n;
 };
 
+// Read this for more information on testing browser storage availability
+// https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#testing_for_availability
+const isStorageAvailable = (type) => {
+    let storage;
+    try {
+        storage = window[type];
+        const x = "__storage_test__";
+        storage.setItem(x, x);
+        storage.removeItem(x);
+        return true;
+    }
+    catch (e) {
+        return (e instanceof DOMException &&
+            e.name === "QuotaExceededError" &&
+            // acknowledge QuotaExceededError only if there's something already stored
+            storage &&
+            storage.length !== 0);
+    }
+};
+
 /**
  * Returns a react-state containing the currently selected language.
  * @returns [lang as string, setLang as SetStateAction] a react-state containing the currently selected language
@@ -90,7 +110,7 @@ function useSelectedLanguage() {
     const [lang, setLang] = React.useState(defaultLang);
     // set the language if the localStorage value has changed
     const handleLocalStorageUpdate = () => {
-        const storedLang = window.localStorage.getItem("next-export-i18n-lang");
+        const storedLang = isStorageAvailable("localStorage") && window.localStorage.getItem("next-export-i18n-lang");
         if (languageDataStore === LanguageDataStore.LOCAL_STORAGE &&
             storedLang &&
             storedLang !== lang &&

--- a/module/src/components/language-switcher/index.tsx
+++ b/module/src/components/language-switcher/index.tsx
@@ -5,6 +5,7 @@ import useLanguageSwitcherIsActive from "../../hooks/use-language-switcher-is-ac
 import i18n from "../../index";
 import { I18N } from "../../types";
 import { LanguageDataStore } from "../../enums/languageDataStore";
+import { checkStorageAvailability } from "../../utils";
 
 type Props = {
   lang: string;
@@ -54,8 +55,12 @@ const LanguageSwitcher = ({
         { shallow: shallow }
       );
     }
-
+    
     if (languageDataStore === LanguageDataStore.LOCAL_STORAGE) {
+      const isLocalStorageAvailable = checkStorageAvailability('localStorage');
+
+      if(!isLocalStorageAvailable) return
+    
       window.localStorage.setItem("next-export-i18n-lang", lang);
       const event = new Event("localStorageLangChange");
       document.dispatchEvent(event);

--- a/module/src/hooks/use-language-switcher-is-active.tsx
+++ b/module/src/hooks/use-language-switcher-is-active.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import i18n from "../index";
 import { I18N } from "../types";
 import { LanguageDataStore } from "../enums/languageDataStore";
+import { checkStorageAvailability } from "../utils";
 
 /**
  * Returns a boolean react-state indicating if the current selected language equals the one passed to the hook.
@@ -32,6 +33,9 @@ export default function useLanguageSwitcherIsActive(currentLang: string) {
 
   const handleLocalStorageUpdate = () => {
     if (languageDataStore === LanguageDataStore.LOCAL_STORAGE) {
+      const isLocalStorageAvailable = checkStorageAvailability('localStorage');
+      if(!isLocalStorageAvailable) return
+      
       let current;
       const localStorageLanguage = window.localStorage.getItem(
         "next-export-i18n-lang"

--- a/module/src/hooks/use-selected-language.tsx
+++ b/module/src/hooks/use-selected-language.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import i18n from "./../index";
 import { I18N } from "../types";
 import { LanguageDataStore } from "../enums/languageDataStore";
-import { isStorageAvailable } from "../utils";
+import { checkStorageAvailability } from "../utils";
 
 /**
  * Returns a react-state containing the currently selected language.
@@ -21,7 +21,7 @@ export default function useSelectedLanguage() {
 
   // set the language if the localStorage value has changed
   const handleLocalStorageUpdate = () => {
-    const storedLang = isStorageAvailable("localStorage") && window.localStorage.getItem("next-export-i18n-lang");
+    const storedLang = checkStorageAvailability("localStorage") && window.localStorage.getItem("next-export-i18n-lang");
 
     if (
       languageDataStore === LanguageDataStore.LOCAL_STORAGE &&

--- a/module/src/hooks/use-selected-language.tsx
+++ b/module/src/hooks/use-selected-language.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import i18n from "./../index";
 import { I18N } from "../types";
 import { LanguageDataStore } from "../enums/languageDataStore";
+import { isStorageAvailable } from "../utils";
 
 /**
  * Returns a react-state containing the currently selected language.
@@ -20,7 +21,7 @@ export default function useSelectedLanguage() {
 
   // set the language if the localStorage value has changed
   const handleLocalStorageUpdate = () => {
-    const storedLang = window.localStorage.getItem("next-export-i18n-lang");
+    const storedLang = isStorageAvailable("localStorage") && window.localStorage.getItem("next-export-i18n-lang");
 
     if (
       languageDataStore === LanguageDataStore.LOCAL_STORAGE &&

--- a/module/src/utils.ts
+++ b/module/src/utils.ts
@@ -1,0 +1,21 @@
+// Read this info https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#testing_for_availability
+
+export const isStorageAvailable = (type : "localStorage" | "sessionStorage") => {
+    let storage;
+
+    try {
+      storage = window[type];
+      const x = "__storage_test__";
+      storage.setItem(x, x);
+      storage.removeItem(x);
+      return true;
+    } catch (e) {
+      return (
+        e instanceof DOMException &&
+        e.name === "QuotaExceededError" &&
+        // acknowledge QuotaExceededError only if there's something already stored
+        storage &&
+        storage.length !== 0
+      );
+    }
+  }

--- a/module/src/utils.ts
+++ b/module/src/utils.ts
@@ -1,4 +1,5 @@
-// Read this info https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#testing_for_availability
+// Read this for more information on testing browser storage availability
+// https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#testing_for_availability
 
 export const isStorageAvailable = (type : "localStorage" | "sessionStorage") => {
     let storage;

--- a/module/src/utils.ts
+++ b/module/src/utils.ts
@@ -1,7 +1,7 @@
 // Read this for more information on testing browser storage availability
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#testing_for_availability
 
-export const isStorageAvailable = (type : "localStorage" | "sessionStorage") => {
+export const checkStorageAvailability = (type : "localStorage" | "sessionStorage") => {
     let storage;
 
     try {


### PR DESCRIPTION
 - Add local storage availability check to prevent crashing even if query is used as the data store.
 - Relates to [this](https://github.com/martinkr/next-export-i18n/issues/80l) issue.