### PR TITLE
Don't useSearchParams if not using query parameters

### DIFF
--- a/module/src/components/language-switcher/index.tsx
+++ b/module/src/components/language-switcher/index.tsx
@@ -30,10 +30,10 @@ const LanguageSwitcher = ({ lang, children }: Props): JSX.Element => {
   // necessary for updating the router's query parameter inside the click handler
   const router = useRouter();
   const pathname = usePathname();
-  const searchParams = useSearchParams()!;
+  const languageDataStore = i18nObj.languageDataStore;
+  const searchParams = languageDataStore === LanguageDataStore.QUERY ? useSearchParams()! : new URLSearchParams();
 
   const i18nObj = i18n() as I18N;
-  const languageDataStore = i18nObj.languageDataStore;
   const createQueryString = useCallback(
     (name: string, value: string) => {
       const params = new URLSearchParams(searchParams.toString());

--- a/module/src/hooks/use-language-switcher-is-active.tsx
+++ b/module/src/hooks/use-language-switcher-is-active.tsx
@@ -14,10 +14,10 @@ import { LanguageDataStore } from "../enums/languageDataStore";
 export default function useLanguageSwitcherIsActive(currentLang: string) {
   const [isActive, setIsActive] = useState<boolean>(false);
   const i18nObj = i18n() as I18N;
-  const searchParams = useSearchParams();
+  const languageDataStore = i18nObj.languageDataStore;
+  const searchParams = languageDataStore === LanguageDataStore.QUERY ? useSearchParams() : new URLSearchParams();
   const langParam = searchParams.get("lang");
   const defaultLang = i18nObj.defaultLang;
-  const languageDataStore = i18nObj.languageDataStore;
 
   useEffect(() => {
     if (languageDataStore === LanguageDataStore.QUERY) {

--- a/module/src/hooks/use-selected-language.tsx
+++ b/module/src/hooks/use-selected-language.tsx
@@ -17,7 +17,7 @@ export default function useSelectedLanguage() {
   const translations = i18nObj.translations;
   const languageDataStore = i18nObj.languageDataStore;
 
-  const searchParams = useSearchParams();
+  const searchParams = languageDataStore === LanguageDataStore.QUERY ? useSearchParams() : new URLSearchParams();
   const langParam = searchParams.get("lang");
   const [lang, setLang] = useState<string>(defaultLang);
 


### PR DESCRIPTION
Should help with #74 when not using query languageDataStore. I can't fix the issue if query languageDataStore is being used because it's just https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout, and the only fix is to follow the instruction to surround the components in a Suspense boundary.