### PR TITLE
Improve link hash support

### DIFF
--- a/module/src/components/link-with-locale/index.tsx
+++ b/module/src/components/link-with-locale/index.tsx
@@ -30,17 +30,18 @@ export default function LinkWithLocale(props: LinkWithLocaleProps) {
   const { href, ...rest } = props;
   const link = useMemo(() => {
     const inputHref = href.toString();
-    if (
-      inputHref.includes("?lang=") ||
-      inputHref.includes("&lang=") ||
-      languageDataStore === LanguageDataStore.LOCAL_STORAGE
-    ) {
+    try {
+      const url = new URL(inputHref, document.baseURI);
+      if (
+        url.searchParams.has("lang") ||
+        languageDataStore === LanguageDataStore.LOCAL_STORAGE
+      ) {
+        return inputHref;
+      }
+      url.searchParams.set("lang", lang);
+      return url.toString();
+    } catch (_e) {
       return inputHref;
-    }
-    if (inputHref.includes("?")) {
-      return `${inputHref}&lang=${lang}`;
-    } else {
-      return `${inputHref}?lang=${lang}`;
     }
   }, [href, lang]);
   return <Link href={link} {...rest} />;

--- a/module/src/components/link-with-locale/index.tsx
+++ b/module/src/components/link-with-locale/index.tsx
@@ -27,7 +27,7 @@ export default function LinkWithLocale(props: LinkWithLocaleProps) {
   const { lang } = useSelectedLanguage();
   const i18nObj = i18n() as I18N;
   const languageDataStore = i18nObj.languageDataStore;
-  const { href, hash, ...rest } = props;
+  const { href, ...rest } = props;
   const link = useMemo(() => {
     const inputHref = href.toString();
     if (
@@ -38,10 +38,10 @@ export default function LinkWithLocale(props: LinkWithLocaleProps) {
       return inputHref;
     }
     if (inputHref.includes("?")) {
-      return `${inputHref}&lang=${lang}` + (hash || '');
+      return `${inputHref}&lang=${lang}`;
     } else {
-      return `${inputHref}?lang=${lang}` + (hash || '');
+      return `${inputHref}?lang=${lang}`;
     }
-  }, [href, hash, lang]);
+  }, [href, lang]);
   return <Link href={link} {...rest} />;
 }


### PR DESCRIPTION
Revert #71, then does a version of it where, for any [valid URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#exceptions) that doesn't already have a lang paramater, as long as LocalStorage is not in use, the lang parameter is properly added to the Link using the [URL constructor with `document.baseURI` as the base](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#parameters) and setting the [searchParams](https://developer.mozilla.org/en-US/docs/Web/API/URL/searchParams).