### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ export default function Component({}) {
     </main>
     </div>
   );
-
+}
 ```
  _File: ./component.js_
 


### PR DESCRIPTION
The example was missing a `}` 